### PR TITLE
Column alignment

### DIFF
--- a/adaptive_components/lib/src/adaptive_column.dart
+++ b/adaptive_components/lib/src/adaptive_column.dart
@@ -105,17 +105,13 @@ class AdaptiveColumn extends StatelessWidget {
                     }
                     int rowGutters = 0;
                     for (AdaptiveContainer rowItem in row) {
+                      double periodicWidth = (MediaQuery.of(context).size.width -
+                          _margin * 2 + _gutter) / _entry.columns;
+
                       // maxWidth equals column width without margin and gutters
                       // divided by the total number of adaptive containers.
-                      double maxWidth = (MediaQuery.of(context).size.width -
-                              _margin * 2 -
-                              _gutter *
-                                  (rowGutters == totalGutters &&
-                                          currentColumns > _entry.columns
-                                      ? 0
-                                      : totalGutters)) /
-                          _entry.columns *
-                          rowItem.columnSpan;
+                      double maxWidth = periodicWidth * rowItem.columnSpan -
+                          _gutter;
                       children.add(
                         ConstrainedBox(
                           constraints: BoxConstraints(

--- a/adaptive_components/lib/src/adaptive_column.dart
+++ b/adaptive_components/lib/src/adaptive_column.dart
@@ -105,6 +105,7 @@ class AdaptiveColumn extends StatelessWidget {
                     }
                     int rowGutters = 0;
                     for (AdaptiveContainer rowItem in row) {
+                      // Calculates the periodic width of 1 column + 1 gutter.
                       double periodicWidth = (MediaQuery.of(context).size.width -
                           _margin * 2 + _gutter) / _entry.columns;
 

--- a/adaptive_components/lib/src/adaptive_column.dart
+++ b/adaptive_components/lib/src/adaptive_column.dart
@@ -105,12 +105,14 @@ class AdaptiveColumn extends StatelessWidget {
                     }
                     int rowGutters = 0;
                     for (AdaptiveContainer rowItem in row) {
-                      // Calculates the periodic width of 1 column + 1 gutter.
+                      // Periodic width is the width of 1 column + 1 gutter.
                       double periodicWidth = (MediaQuery.of(context).size.width -
                           _margin * 2 + _gutter) / _entry.columns;
 
-                      // maxWidth equals column width without margin and gutters
-                      // divided by the total number of adaptive containers.
+                      // For a row item with a column span of k, its width is
+                      // k * column + (k - 1) * gutter, which equals
+                      // k * (column + gutter) - gutter, which is
+                      // k * periodicWidth - gutter.
                       double maxWidth = periodicWidth * rowItem.columnSpan -
                           _gutter;
                       children.add(


### PR DESCRIPTION
Fixes column alignment.

## Description
```
|<------------------ Screen width. ------------------>|

+---+-----+-+-----+-+-----+-+-----+-+-----+-+-----+---+
| M |  C  |G|  C  |G|  C  |G|  C  |G|  C  |G|  C  | M |
+---+-----+-+-----+-+-----+-+-----+-+-----+-+-----+---+

+---+-----+-+-----+-+-----+-+-----+-+-------------+---+
| M |  C  |G|  C  |G|  C  |G|  C  |G|             | M |
+---+-----+-+-----+-+-----+-+-----+-+-------------+---+

+---+-------------+-+-----+-+-----+-+-------------+---+
| M | Wide Column |G|  C  |G|  C  |G|             | M |
+---+-------------+-+-----+-+-----+-+-------------+---+
```

For example, in a 6-column adaptive layout, the width of the screen is made up of 2 margins (*M*), 6 basic columns (*C*), and 5 gutters (*G*).

In this layout, a *k*-times wide column will have a width of *kC* + (*k*-1)*G*, or equivalently *k*(*C*+*G*) - *G*.

Therefore, we calculate the `periodicWidth`, which is *C* + *G*, and use it to calculate the width of each wide column. This guarantees that columns are aligned.

## Screenshot
<img width="833" alt="adaptive-columns-after" src="https://user-images.githubusercontent.com/23219899/94531270-9cfc3600-023c-11eb-8ebc-995a62ceceaa.png">
