### PR TITLE
Correct types for `Switch.onChanged`.

### DIFF
--- a/adaptive_navigation/example/lib/custom_scaffold.dart
+++ b/adaptive_navigation/example/lib/custom_scaffold.dart
@@ -63,7 +63,7 @@ class _CustomScaffoldDemoState extends State<CustomScaffoldDemo> {
             value: _fabInRail,
             onChanged: (value) {
               setState(() {
-                _fabInRail = value!;
+                _fabInRail = value;
               });
             },
           ),
@@ -73,7 +73,7 @@ class _CustomScaffoldDemoState extends State<CustomScaffoldDemo> {
             value: _includeBaseDestinationsInMenu,
             onChanged: (value) {
               setState(() {
-                _includeBaseDestinationsInMenu = value!;
+                _includeBaseDestinationsInMenu = value;
               });
             },
           ),

--- a/adaptive_navigation/example/lib/default_scaffold.dart
+++ b/adaptive_navigation/example/lib/default_scaffold.dart
@@ -60,7 +60,7 @@ class _DefaultScaffoldDemoState extends State<DefaultScaffoldDemo> {
             value: _fabInRail,
             onChanged: (value) {
               setState(() {
-                _fabInRail = value!;
+                _fabInRail = value;
               });
             },
           ),
@@ -70,7 +70,7 @@ class _DefaultScaffoldDemoState extends State<DefaultScaffoldDemo> {
             value: _includeBaseDestinationsInMenu,
             onChanged: (value) {
               setState(() {
-                _includeBaseDestinationsInMenu = value!;
+                _includeBaseDestinationsInMenu = value;
               });
             },
           ),

--- a/adaptive_navigation/lib/src/adaptive_app_bar.dart
+++ b/adaptive_navigation/lib/src/adaptive_app_bar.dart
@@ -34,7 +34,7 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.leadingWidth,
   })  : assert(elevation == null || elevation >= 0.0),
         preferredSize = Size.fromHeight(toolbarHeight ??
-            kToolbarHeight + (bottom?.preferredSize?.height ?? 0.0)),
+            kToolbarHeight + (bottom?.preferredSize.height ?? 0.0)),
         super(key: key);
 
   final Widget? leading;


### PR DESCRIPTION
Since a change in `flutter/flutter`, `Switch.onChanged` has changed from type `ValueChanged<bool?>?` to `ValueChanged<bool>?`

This PR updates the type of `Switch.onChanged` used in the adaptive packages.