### PR TITLE
Fixed the adaptive_components library name

### DIFF
--- a/adaptive_components/lib/adaptive_components.dart
+++ b/adaptive_components/lib/adaptive_components.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library adaptive_breakpoints;
+library adaptive_components;
 
 export 'src/adaptive_column.dart';
 export 'src/adaptive_container.dart';


### PR DESCRIPTION
It was `adaptive_breakpoints`, which is confusing beacuse there is another library in this repo with the same name. It also messes up the pub.dev docs. Fixes material-foundation/flutter-packages#329 