### PR TITLE
pass key to scaffolds to enable endDrawer

### DIFF
--- a/adaptive_navigation/CHANGELOG.md
+++ b/adaptive_navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.0.5] - November 18, 2021
+
+Add missing key to Scaffold widgets.
+
 # [0.0.4] - July 14, 2021
 
 Adopt `flutter_lints` and migrate from `RaisedButton` to `ElevatedButton`.

--- a/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -206,6 +206,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
             includeBaseDestinationsInMenu ? 0 : bottomNavigationOverflow)
         : <AdaptiveScaffoldDestination>[];
     return Scaffold(
+      key: key,
       body: body,
       appBar: appBar,
       drawer: drawerDestinations.isEmpty
@@ -238,6 +239,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
             includeBaseDestinationsInMenu ? 0 : railDestinationsOverflow)
         : <AdaptiveScaffoldDestination>[];
     return Scaffold(
+      key: key,
       appBar: appBar,
       drawer: drawerDestinations.isEmpty
           ? null
@@ -286,6 +288,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
 
   Widget _buildNavigationDrawerScaffold() {
     return Scaffold(
+      key: key,
       body: body,
       appBar: appBar,
       drawer: Drawer(
@@ -346,6 +349,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
         ),
         Expanded(
           child: Scaffold(
+            key: key,
             appBar: appBar,
             body: body,
             floatingActionButton: floatingActionButton,

--- a/adaptive_navigation/pubspec.yaml
+++ b/adaptive_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_navigation
 description: A component to be used in place of the Scaffold widget when you want automatic switching between Navigation Rail and Bottom Navigation Bar.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/material-components/material-components-flutter-adaptive
 
 environment:


### PR DESCRIPTION
I was unable to open an endDrawer because the key passed to AdaptiveNavigationScaffold was not beeing passed around to the created Scaffolds