### PR TITLE
add navRailMinWidth parameter

### DIFF
--- a/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -226,6 +226,8 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
           ? null
           : _defaultDrawer(drawerDestinations, context),
       bottomNavigationBar: BottomNavigationBar(
+        selectedFontSize: 12,
+        unselectedFontSize: 12,
         items: [
           for (final destination in bottomDestinations)
             BottomNavigationBarItem(
@@ -305,32 +307,37 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
       key: key,
       body: body,
       appBar: appBar,
-      drawer: Drawer(
-        child: Column(
-          children: [
-            // TODO: Find a better way to write `drawerHeader!`
-            if (drawerHeader != null) drawerHeader!,
-            for (final destination in destinations)
-              ListTileTheme(
-                  dense: navRailMinWidth != null && navRailMinWidth! < 72
-                      ? true
-                      : false,
-                  horizontalTitleGap:
-                      navRailMinWidth != null && navRailMinWidth! < 72
-                          ? 0
-                          : null,
-                  textColor: Theme.of(context).unselectedWidgetColor,
-                  iconColor: Theme.of(context).unselectedWidgetColor,
-                  child: ListTile(
-                    leading: Icon(destination.icon),
-                    title: Text(destination.title),
-                    selected:
-                        destinations.indexOf(destination) == selectedIndex,
-                    onTap: () => _destinationTapped(destination),
-                  )),
-          ],
-        ),
-      ),
+      drawer: Container(
+          width: navRailMinWidth != null && navRailMinWidth! < 72 ? 160 : null,
+          child: Drawer(
+            child: Column(
+              children: [
+                // TODO: Find a better way to write `drawerHeader!`
+                if (drawerHeader != null) drawerHeader!,
+                for (final destination in destinations)
+                  ListTileTheme(
+                      dense: navRailMinWidth != null && navRailMinWidth! < 72
+                          ? true
+                          : false,
+                      horizontalTitleGap:
+                          navRailMinWidth != null && navRailMinWidth! < 72
+                              ? 0
+                              : null,
+                      textColor: Theme.of(context).unselectedWidgetColor,
+                      iconColor: Theme.of(context).unselectedWidgetColor,
+                      child: ListTile(
+                        leading: Icon(destination.icon),
+                        title: Text(destination.title),
+                        selected:
+                            destinations.indexOf(destination) == selectedIndex,
+                        onTap: () {
+                          _destinationTapped(destination);
+                          Navigator.of(context).pop();
+                        },
+                      )),
+              ],
+            ),
+          )),
       floatingActionButton: floatingActionButton,
       floatingActionButtonLocation: floatingActionButtonLocation,
       floatingActionButtonAnimator: floatingActionButtonAnimator,

--- a/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -68,6 +68,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     this.navigationTypeResolver,
     this.drawerHeader,
     this.fabInRail = true,
+    this.navRailMinWidth,
     this.includeBaseDestinationsInMenu = true,
   }) : super(key: key);
 
@@ -162,6 +163,9 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
   /// [floatingActionButtonAnimation] are ignored.
   final bool fabInRail;
 
+  /// 72 by default, 56 for compact, 48 for VS Code look
+  final double? navRailMinWidth;
+
   /// Weather the overflow menu defaults to include overflow destinations and
   /// the overflow destinations.
   final bool includeBaseDestinationsInMenu;
@@ -247,6 +251,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
       body: Row(
         children: [
           NavigationRail(
+            minWidth: navRailMinWidth,
             leading: fabInRail ? floatingActionButton : null,
             destinations: [
               for (final destination in railDestinations)

--- a/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -332,7 +332,6 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                             destinations.indexOf(destination) == selectedIndex,
                         onTap: () {
                           _destinationTapped(destination);
-                          Navigator.of(context).pop();
                         },
                       )),
               ],

--- a/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -180,26 +180,35 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     }
   }
 
-  Drawer _defaultDrawer(List<AdaptiveScaffoldDestination> destinations) {
+  Drawer _defaultDrawer(
+      List<AdaptiveScaffoldDestination> destinations, BuildContext context) {
     return Drawer(
       child: ListView(
         children: [
           // TODO: Find a better way to write `drawerHeader!`
           if (drawerHeader != null) drawerHeader!,
           for (int i = 0; i < destinations.length; i++)
-            ListTile(
-              leading: Icon(destinations[i].icon),
-              title: Text(destinations[i].title),
-              onTap: () {
-                onDestinationSelected?.call(i);
-              },
-            )
+            ListTileTheme(
+                dense: navRailMinWidth != null && navRailMinWidth! < 72
+                    ? true
+                    : false,
+                horizontalTitleGap:
+                    navRailMinWidth != null && navRailMinWidth! < 72 ? 0 : null,
+                textColor: Theme.of(context).unselectedWidgetColor,
+                iconColor: Theme.of(context).unselectedWidgetColor,
+                child: ListTile(
+                  leading: Icon(destinations[i].icon),
+                  title: Text(destinations[i].title),
+                  onTap: () {
+                    onDestinationSelected?.call(i);
+                  },
+                ))
         ],
       ),
     );
   }
 
-  Widget _buildBottomNavigationScaffold() {
+  Widget _buildBottomNavigationScaffold(BuildContext context) {
     const int bottomNavigationOverflow = 5;
     final bottomDestinations = destinations.sublist(
       0,
@@ -215,7 +224,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
       appBar: appBar,
       drawer: drawerDestinations.isEmpty
           ? null
-          : _defaultDrawer(drawerDestinations),
+          : _defaultDrawer(drawerDestinations, context),
       bottomNavigationBar: BottomNavigationBar(
         items: [
           for (final destination in bottomDestinations)
@@ -232,7 +241,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     );
   }
 
-  Widget _buildNavigationRailScaffold() {
+  Widget _buildNavigationRailScaffold(BuildContext context) {
     const int railDestinationsOverflow = 7;
     final railDestinations = destinations.sublist(
       0,
@@ -247,7 +256,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
       appBar: appBar,
       drawer: drawerDestinations.isEmpty
           ? null
-          : _defaultDrawer(drawerDestinations),
+          : _defaultDrawer(drawerDestinations, context),
       body: Row(
         children: [
           NavigationRail(
@@ -291,7 +300,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     );
   }
 
-  Widget _buildNavigationDrawerScaffold() {
+  Widget _buildNavigationDrawerScaffold(BuildContext context) {
     return Scaffold(
       key: key,
       body: body,
@@ -302,12 +311,23 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
             // TODO: Find a better way to write `drawerHeader!`
             if (drawerHeader != null) drawerHeader!,
             for (final destination in destinations)
-              ListTile(
-                leading: Icon(destination.icon),
-                title: Text(destination.title),
-                selected: destinations.indexOf(destination) == selectedIndex,
-                onTap: () => _destinationTapped(destination),
-              ),
+              ListTileTheme(
+                  dense: navRailMinWidth != null && navRailMinWidth! < 72
+                      ? true
+                      : false,
+                  horizontalTitleGap:
+                      navRailMinWidth != null && navRailMinWidth! < 72
+                          ? 0
+                          : null,
+                  textColor: Theme.of(context).unselectedWidgetColor,
+                  iconColor: Theme.of(context).unselectedWidgetColor,
+                  child: ListTile(
+                    leading: Icon(destination.icon),
+                    title: Text(destination.title),
+                    selected:
+                        destinations.indexOf(destination) == selectedIndex,
+                    onTap: () => _destinationTapped(destination),
+                  )),
           ],
         ),
       ),
@@ -330,7 +350,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     );
   }
 
-  Widget _buildPermanentDrawerScaffold() {
+  Widget _buildPermanentDrawerScaffold(BuildContext context) {
     return Row(
       children: [
         Drawer(
@@ -339,12 +359,23 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
               // TODO: Find a better way to write `drawerHeader!`
               if (drawerHeader != null) drawerHeader!,
               for (final destination in destinations)
-                ListTile(
-                  leading: Icon(destination.icon),
-                  title: Text(destination.title),
-                  selected: destinations.indexOf(destination) == selectedIndex,
-                  onTap: () => _destinationTapped(destination),
-                ),
+                ListTileTheme(
+                    dense: navRailMinWidth != null && navRailMinWidth! < 72
+                        ? true
+                        : false,
+                    horizontalTitleGap:
+                        navRailMinWidth != null && navRailMinWidth! < 72
+                            ? 0
+                            : null,
+                    textColor: Theme.of(context).unselectedWidgetColor,
+                    iconColor: Theme.of(context).unselectedWidgetColor,
+                    child: ListTile(
+                      leading: Icon(destination.icon),
+                      title: Text(destination.title),
+                      selected:
+                          destinations.indexOf(destination) == selectedIndex,
+                      onTap: () => _destinationTapped(destination),
+                    )),
             ],
           ),
         ),
@@ -386,13 +417,13 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
     final navigationType = navigationTypeResolver(context);
     switch (navigationType) {
       case NavigationType.bottom:
-        return _buildBottomNavigationScaffold();
+        return _buildBottomNavigationScaffold(context);
       case NavigationType.rail:
-        return _buildNavigationRailScaffold();
+        return _buildNavigationRailScaffold(context);
       case NavigationType.drawer:
-        return _buildNavigationDrawerScaffold();
+        return _buildNavigationDrawerScaffold(context);
       case NavigationType.permanentDrawer:
-        return _buildPermanentDrawerScaffold();
+        return _buildPermanentDrawerScaffold(context);
     }
   }
 


### PR DESCRIPTION
I am trying to achieve the VS Code compact rail look, with top and bottom icons.

![image](https://user-images.githubusercontent.com/157766/142733578-aae59c30-ec05-46ff-b7ff-6ee56500d181.png)

But it looks like the minwidth parameter is hidden in adaptive-navigation. I tried @override-ing but of course the function `_buildNavigationRailScaffold()` to build the NavigationRail is private. Lol. Sadly, minwidth is not part of any kind of NavigationRailTheme.