### PR TITLE
Fixed misaligned leading icon with navigation rail

### DIFF
--- a/adaptive_navigation/example/lib/custom_scaffold.dart
+++ b/adaptive_navigation/example/lib/custom_scaffold.dart
@@ -18,7 +18,10 @@ class _CustomScaffoldDemoState extends State<CustomScaffoldDemo> {
     return AdaptiveNavigationScaffold(
       selectedIndex: 0,
       destinations: _allDestinations.sublist(0, _destinationCount),
-      appBar: AdaptiveAppBar(title: const Text('Custom Demo')),
+      appBar: AdaptiveAppBar(
+        title: const Text('Custom Demo'),
+        leading: const Icon(Icons.menu),
+      ),
       body: _body(),
       floatingActionButton: FloatingActionButton(
         child: const Icon(Icons.add),

--- a/adaptive_navigation/example/lib/default_scaffold.dart
+++ b/adaptive_navigation/example/lib/default_scaffold.dart
@@ -22,7 +22,10 @@ class _DefaultScaffoldDemoState extends State<DefaultScaffoldDemo> {
     return AdaptiveNavigationScaffold(
       selectedIndex: 0,
       destinations: _allDestinations.sublist(0, _destinationCount),
-      appBar: AdaptiveAppBar(title: const Text('Default Demo')),
+      appBar: AdaptiveAppBar(
+        title: const Text('Default Demo'),
+        leading: const Icon(Icons.menu),
+      ),
       body: _body(),
       floatingActionButton: FloatingActionButton(
         child: const Icon(Icons.add),

--- a/adaptive_navigation/lib/src/adaptive_app_bar.dart
+++ b/adaptive_navigation/lib/src/adaptive_app_bar.dart
@@ -67,6 +67,13 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    double setLeadingWidth() {
+      if (leadingWidth != null) {
+        return leadingWidth!;
+      }
+      return Theme.of(context).useMaterial3 ? 80.0 : 72.0;
+    }
+
     return AppBar(
       key: key,
       leading: leading,
@@ -89,7 +96,8 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
       bottomOpacity: bottomOpacity,
       toolbarHeight: toolbarHeight,
       // TODO Change to work correctly on xsmall window as well
-      leadingWidth: leadingWidth ?? 72.0,
+      leadingWidth: setLeadingWidth(),
+      // leadingWidth ?? Theme.of(context).useMaterial3 ? 80.0 : 72.0,
       toolbarTextStyle: toolbarTextStyle,
       titleTextStyle: titleTextStyle,
       systemOverlayStyle: systemOverlayStyle,

--- a/adaptive_navigation/lib/src/adaptive_app_bar.dart
+++ b/adaptive_navigation/lib/src/adaptive_app_bar.dart
@@ -88,9 +88,8 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
       toolbarOpacity: toolbarOpacity,
       bottomOpacity: bottomOpacity,
       toolbarHeight: toolbarHeight,
-      // TODO(https://github.com/material-components/material-components-flutter-adaptive/issues/2):
-      // This needs to depend on whether the rail is showing or not.
-      leadingWidth: 72.0,
+      // TODO Change to work correctly on xsmall window as well
+      leadingWidth: leadingWidth ?? 72.0,
       toolbarTextStyle: toolbarTextStyle,
       titleTextStyle: titleTextStyle,
       systemOverlayStyle: systemOverlayStyle,

--- a/adaptive_navigation/lib/src/adaptive_app_bar.dart
+++ b/adaptive_navigation/lib/src/adaptive_app_bar.dart
@@ -90,8 +90,7 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
       toolbarHeight: toolbarHeight,
       // TODO(https://github.com/material-components/material-components-flutter-adaptive/issues/2):
       // This needs to depend on whether the rail is showing or not.
-      leadingWidth:
-          getWindowType(context) == AdaptiveWindowType.medium ? 72.0 : 56.0,
+      leadingWidth: 72.0,
       toolbarTextStyle: toolbarTextStyle,
       titleTextStyle: titleTextStyle,
       systemOverlayStyle: systemOverlayStyle,

--- a/adaptive_navigation/test/adaptive_navigation_test.dart
+++ b/adaptive_navigation/test/adaptive_navigation_test.dart
@@ -3,22 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:adaptive_navigation/adaptive_navigation.dart';
 
 void main() {
+  const _allDestinations = [
+    AdaptiveScaffoldDestination(title: 'Alarm', icon: Icons.alarm),
+    AdaptiveScaffoldDestination(title: 'Book', icon: Icons.book),
+    AdaptiveScaffoldDestination(title: 'Cake', icon: Icons.cake),
+    AdaptiveScaffoldDestination(title: 'Directions', icon: Icons.directions),
+    AdaptiveScaffoldDestination(title: 'Email', icon: Icons.email),
+    AdaptiveScaffoldDestination(title: 'Favorite', icon: Icons.favorite),
+    AdaptiveScaffoldDestination(title: 'Group', icon: Icons.group),
+    AdaptiveScaffoldDestination(title: 'Headset', icon: Icons.headset),
+    AdaptiveScaffoldDestination(title: 'Info', icon: Icons.info),
+  ];
   testWidgets('Adaptive Navigation test', (WidgetTester tester) async {
     const mediumWindowSize = Size(960, 1000);
     tester.binding.window.physicalSizeTestValue = mediumWindowSize;
     tester.binding.window.devicePixelRatioTestValue = 1.0;
-
-    const _allDestinations = [
-      AdaptiveScaffoldDestination(title: 'Alarm', icon: Icons.alarm),
-      AdaptiveScaffoldDestination(title: 'Book', icon: Icons.book),
-      AdaptiveScaffoldDestination(title: 'Cake', icon: Icons.cake),
-      AdaptiveScaffoldDestination(title: 'Directions', icon: Icons.directions),
-      AdaptiveScaffoldDestination(title: 'Email', icon: Icons.email),
-      AdaptiveScaffoldDestination(title: 'Favorite', icon: Icons.favorite),
-      AdaptiveScaffoldDestination(title: 'Group', icon: Icons.group),
-      AdaptiveScaffoldDestination(title: 'Headset', icon: Icons.headset),
-      AdaptiveScaffoldDestination(title: 'Info', icon: Icons.info),
-    ];
 
     await tester.pumpWidget(
       MaterialApp(
@@ -37,5 +36,42 @@ void main() {
       ),
     );
     expect(find.byType(AdaptiveNavigationScaffold), findsOneWidget);
+  });
+  testWidgets('Adaptive App Bar leading icon axis test',
+      (WidgetTester tester) async {
+    const xlargeWindowSize = Size(1920, 1080);
+    tester.binding.window.physicalSizeTestValue = xlargeWindowSize;
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveNavigationScaffold(
+          selectedIndex: 0,
+          destinations: _allDestinations,
+          appBar: AdaptiveAppBar(
+            title: const Text('Default Demo'),
+            leading: const Icon(
+              Icons.more_vert,
+              key: Key('target'),
+            ),
+          ),
+          floatingActionButton: FloatingActionButton(
+            child: const Icon(Icons.add),
+            onPressed: () {},
+          ),
+          body: Container(
+            color: Colors.green,
+          ),
+          navigationTypeResolver: (context) {
+            return NavigationType.rail;
+          },
+        ),
+      ),
+    );
+
+    expect(
+      tester.getCenter(find.byKey(const Key('target'))).dx,
+      tester.getCenter(find.byIcon(Icons.alarm)).dx,
+    );
   });
 }

--- a/adaptive_navigation/test/adaptive_navigation_test.dart
+++ b/adaptive_navigation/test/adaptive_navigation_test.dart
@@ -45,10 +45,51 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: AdaptiveNavigationScaffold(
           selectedIndex: 0,
           destinations: _allDestinations,
           appBar: AdaptiveAppBar(
+            title: const Text('Default Demo'),
+            leading: const Icon(
+              Icons.more_vert,
+              key: Key('target'),
+            ),
+          ),
+          floatingActionButton: FloatingActionButton(
+            child: const Icon(Icons.add),
+            onPressed: () {},
+          ),
+          body: Container(
+            color: Colors.green,
+          ),
+          navigationTypeResolver: (context) {
+            return NavigationType.rail;
+          },
+        ),
+      ),
+    );
+
+    expect(
+      tester.getCenter(find.byKey(const Key('target'))).dx,
+      tester.getCenter(find.byIcon(Icons.alarm)).dx,
+    );
+  });
+
+  testWidgets('Adaptive App Bar leading icon axis test with Material3',
+      (WidgetTester tester) async {
+    const xlargeWindowSize = Size(1920, 1080);
+    tester.binding.window.physicalSizeTestValue = xlargeWindowSize;
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: AdaptiveNavigationScaffold(
+          selectedIndex: 0,
+          destinations: _allDestinations,
+          appBar: AdaptiveAppBar(
+            leadingWidth: 80,
             title: const Text('Default Demo'),
             leading: const Icon(
               Icons.more_vert,


### PR DESCRIPTION
material-foundation/flutter-packages#320 

Always use rails for testing
```dart
      navigationTypeResolver: (context) {
        return NavigationType.rail;
      },
```

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/59682979/168704332-e87e22fb-2445-499c-aa85-781de15b9ef9.png">
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/59682979/168704352-68165a20-7009-4e3c-a01f-8d239f0b24b3.png">
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/59682979/168704410-168b7533-75bb-4e9f-87b9-019c47dd1303.png">



Note: still does not work correctly in xsmall window