### PR TITLE
Add information about `flutter_adaptive_scaffold`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
+# Adaptive Material Components for Flutter
 A collection of packages for applying adaptive behavior from Material Design to Flutter apps.
 
+## Material 2
 Package | pub
 --- | ---
 [adaptive_navigation](./adaptive_navigation/) | [![pub package](https://img.shields.io/pub/v/adaptive_navigation.svg)](https://pub.dev/packages/adaptive_navigation)
 [adaptive_breakpoints](./adaptive_breakpoints/) | [![pub package](https://img.shields.io/pub/v/adaptive_breakpoints.svg)](https://pub.dev/packages/adaptive_breakpoints)
 [adaptive_components](./adaptive_components/) | [![pub package](https://img.shields.io/pub/v/adaptive_components.svg)](https://pub.dev/packages/adaptive_components)
+
+## Material 3
+Package | pub
+--- | ---
+[flutter_adaptive_scaffold](https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold) | [![pub package](https://img.shields.io/pub/v/adaptive_scaffold.svg)](https://pub.dev/packages/flutter_adaptive_scaffold)


### PR DESCRIPTION
Designers interested in the M3 spec will end up [here](https://m3.material.io/), then may point developers [here](https://github.com/material-components). If that developer is a flutter developer, it is likely that they will read this `README.md`. It should be documented that:

1. This README.md currently contains links to packages that implement the M2 spec. 
2. There are packages maintained by the flutter team like `flutter_adaptive_scaffold` that implement the M3 design spec.
