### PR TITLE
Update the library version image with the correct Adaptive Scaffold Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Package | pub
 ## Material 3
 Package | pub
 --- | ---
-[flutter_adaptive_scaffold](https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold) | [![pub package](https://img.shields.io/pub/v/adaptive_scaffold.svg)](https://pub.dev/packages/flutter_adaptive_scaffold)
+[flutter_adaptive_scaffold](https://github.com/flutter/packages/tree/main/packages/flutter_adaptive_scaffold) | [![pub package](https://img.shields.io/pub/v/flutter_adaptive_scaffold.svg)](https://pub.dev/packages/flutter_adaptive_scaffold)


### PR DESCRIPTION
The library was referincing to the adaptive_scaffold library which is the wrong one. This fixes it. 